### PR TITLE
Update Python version requirement to 3.11 or higher (#11)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,16 @@
 [project]
 name = "syna"
-version = "0.2.0a1"
+version = "0.2.0"
 description = "Syna is a lightweight machine learning framework inspired by DeZero."
 readme = "README.md"
 authors = [
     { name = "sql-hkr", email = "sql.hkr@gmail.com" }
 ]
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 classifiers = [
     "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [


### PR DESCRIPTION
This pull request updates the `pyproject.toml` configuration for the `syna` project to prepare for a stable release and expand Python version compatibility.

Project versioning and Python compatibility:

* Bumped the project version from `0.2.0a1` (alpha) to the stable `0.2.0` release.
* Lowered the minimum required Python version from `3.13` to `3.11` and updated the classifiers to include support for Python 3.11 and 3.12.